### PR TITLE
Fix: Ensure deciphering phase always follows interception

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -142,10 +142,8 @@ function handleGuess(gameState, player, guess) {
 
         if (isCorrect) {
             newGameState.teams[opponentTeam].score.interceptions++;
-            newGameState = advanceTurn(newGameState); // Il turno finisce
-        } else {
-            newGameState.phase = 'deciphering'; // Si passa alla fase di decifrazione
         }
+        newGameState.phase = 'deciphering'; // Si passa sempre alla fase di decifrazione
          newGameState.turnResult = result;
 
     } else if (phase === 'deciphering') {


### PR DESCRIPTION
The previous logic would end the turn immediately after a successful interception, skipping the mandatory deciphering phase for the current team. This change modifies the `handleGuess` function in `server/game.js` to ensure that the game always transitions to the `deciphering` phase after an `interception` attempt, regardless of the outcome. This aligns the game's behavior with the official rules.